### PR TITLE
add helpful fields in schedule admin list

### DIFF
--- a/symposion/schedule/admin.py
+++ b/symposion/schedule/admin.py
@@ -5,14 +5,24 @@ from symposion.schedule.models import Schedule, Day, Room, SlotKind, Slot, SlotR
 
 admin.site.register(Schedule)
 admin.site.register(Day)
-admin.site.register(Room)
-admin.site.register(SlotKind)
+admin.site.register(
+    Room,
+    list_display=("name", "order", "schedule"),
+    list_filter=("schedule",)
+)
+admin.site.register(
+    SlotKind,
+    list_display=("label", "schedule"),
+)
 admin.site.register(
     Slot,
-    list_display=("day", "start", "end", "kind")
+    list_display=("day", "start", "end", "kind", "content")
 )
 admin.site.register(
     SlotRoom,
     list_display=("slot", "room")
 )
-admin.site.register(Presentation)
+admin.site.register(
+    Presentation,
+    list_filter=("section", "cancelled", "slot")
+)


### PR DESCRIPTION
This adds some fields to the list view for the schedule app. It makes dealing with the admin interface a little easier.

![admin](https://cloud.githubusercontent.com/assets/529748/8710522/f9794148-2b0f-11e5-992b-e4a1955b0269.png)
