### PR TITLE
allow speaker to designate reviewer for all of their talks

### DIFF
--- a/symposion/speakers/forms.py
+++ b/symposion/speakers/forms.py
@@ -14,6 +14,7 @@ class SpeakerForm(forms.ModelForm):
             "biography",
             "photo",
             "twitter_username",
+            "reviewer",
         ]
         widgets = {
             "biography": MarkItUpWidget(),

--- a/symposion/speakers/migrations/0003_auto__add_field_speaker_reviewer.py
+++ b/symposion/speakers/migrations/0003_auto__add_field_speaker_reviewer.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Speaker.reviewer'
+        db.add_column(u'speakers_speaker', 'reviewer',
+                      self.gf('django.db.models.fields.EmailField')(default='', max_length=75, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Speaker.reviewer'
+        db.delete_column(u'speakers_speaker', 'reviewer')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'speakers.speaker': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Speaker'},
+            '_biography_rendered': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'annotation': ('django.db.models.fields.TextField', [], {}),
+            'biography': ('markitup.fields.MarkupField', [], {'no_rendered_field': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invite_email': ('django.db.models.fields.CharField', [], {'max_length': '200', 'unique': 'True', 'null': 'True', 'db_index': 'True'}),
+            'invite_token': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'reviewer': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'twitter_username': ('django.db.models.fields.CharField', [], {'max_length': '15', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'speaker_profile'", 'unique': 'True', 'null': 'True', 'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['speakers']

--- a/symposion/speakers/models.py
+++ b/symposion/speakers/models.py
@@ -24,6 +24,10 @@ class Speaker(models.Model):
         blank=True,
         help_text="Your Twitter account"
     )
+    reviewer = models.EmailField(
+        blank=True,
+        help_text=("email of a person who will be allowed to review and approve the produced video of your talk(s)."),
+    )
     annotation = models.TextField()  # staff only
     invite_email = models.CharField(max_length=200, unique=True, null=True, db_index=True)
     invite_token = models.CharField(max_length=40, db_index=True)


### PR DESCRIPTION
This adds an optional field to the Speaker model similar to what exists in the Proposal model.

This is admittedly a workaround for allowing speakers to update their information to add reviewers. Due to the field being added to Proposals, editing a proposal will not automagically make the new information available via the Presentation model.

One approach I had thought of was to add a property to the presentation that would return the reviewer based on getting it from the subclass of the ProposalBase, similar to the existing proposal property. That seems a bit janky, and adding the field to the Speaker model seemed less janky.

But, who knows.

I'd rethink this before ultimately seeing if upstream wants a model change like that. I think the twitter field is a pretty good idea for upstream, but not sure about this being a part of the Speaker model.