### PR TITLE
Redact "additional notes" fields

### DIFF
--- a/symposion/utils/anonymous_review.py
+++ b/symposion/utils/anonymous_review.py
@@ -7,20 +7,20 @@ class ProposalProxy(object):
     def __init__(self, proposal):
         self.__proposal__ = proposal
 
-     def __getattr__(self, attr):
-         ''' Overridden getattr to anonymize speaker data '''
+    def __getattr__(self, attr):
+        ''' Overridden getattr to anonymize speaker data '''
 
-         if attr == "speaker":
+        if attr == "speaker":
              return Parrot("Primary Speaker")
-         elif attr == "additional_speakers":
+        elif attr == "additional_speakers":
              return None
-         elif attr == "speakers":
+        elif attr == "speakers":
              return self._speakers
-         elif attr == "additional_notes" :
+        elif attr == "additional_notes" :
              return Parrot("Additional Notes")
-         elif attr == "additional_notes_html":
+        elif attr == "additional_notes_html":
              return Parrot("Additional Notes HTML")
-         else:
+        else:
              return getattr(self.__proposal__, attr)
 
     def _speakers(self):

--- a/symposion/utils/anonymous_review.py
+++ b/symposion/utils/anonymous_review.py
@@ -11,17 +11,17 @@ class ProposalProxy(object):
         ''' Overridden getattr to anonymize speaker data '''
 
         if attr == "speaker":
-             return Parrot("Primary Speaker")
+            return Parrot("Primary Speaker")
         elif attr == "additional_speakers":
-             return None
+            return None
         elif attr == "speakers":
-             return self._speakers
+            return self._speakers
         elif attr == "additional_notes" :
-             return Parrot("Additional Notes")
+            return Parrot("Additional Notes")
         elif attr == "additional_notes_html":
-             return Parrot("Additional Notes HTML")
+            return Parrot("Additional Notes HTML")
         else:
-             return getattr(self.__proposal__, attr)
+            return getattr(self.__proposal__, attr)
 
     def _speakers(self):
         for i, j in enumerate(self.__proposal__.speakers()):

--- a/symposion/utils/anonymous_review.py
+++ b/symposion/utils/anonymous_review.py
@@ -7,17 +7,21 @@ class ProposalProxy(object):
     def __init__(self, proposal):
         self.__proposal__ = proposal
 
-    def __getattr__(self, attr):
-        ''' Overridden __getattr__ that hides the available speakers. '''
+     def __getattr__(self, attr):
+         ''' Overridden getattr to anonymize speaker data '''
 
-        if attr == "speaker":
-            return Parrot("Primary Speaker")
-        elif attr == "additional_speakers":
-            return None
-        elif attr == "speakers":
-            return self._speakers
-        else:
-            return getattr(self.__proposal__, attr)
+         if attr == "speaker":
+             return Parrot("Primary Speaker")
+         elif attr == "additional_speakers":
+             return None
+         elif attr == "speakers":
+             return self._speakers
+         elif attr == "additional_notes" :
+             return Parrot("Additional Notes")
+         elif attr == "additional_notes_html":
+             return Parrot("Additional Notes HTML")
+         else:
+             return getattr(self.__proposal__, attr)
 
     def _speakers(self):
         for i, j in enumerate(self.__proposal__.speakers()):


### PR DESCRIPTION
This change should replace the information in the "additional notes" and "additional notes HTML" proposal fields with defaulted text when creating a ProxyProposal object. The ProxyProposal is the model that gets used when redacting information on the review detail page.